### PR TITLE
feat: Add content and styling to secondary pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — About</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>About</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>About Us</h1><p class='lede'>Our mission is to make education accessible and engaging for everyone.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Blog</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Blog</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>Blog</h1><p class='lede'>News, updates, and articles from the Stomatomi team.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/careers.html
+++ b/careers.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Careers</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Careers</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>Careers</h1><p class='lede'>Join our team and help us build the future of education.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/get-started.html
+++ b/get-started.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Get Started</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Get Started</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>Get Started</h1><p class='lede'>Join Stomatomi today and revolutionize your learning experience.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/guides.html
+++ b/guides.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Guides</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Guides</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>Guides</h1><p class='lede'>In-depth guides to get the most out of Stomatomi.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/help-center.html
+++ b/help-center.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Help Center</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Help Center</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>Help Center</h1><p class='lede'>Find answers to your questions and get support.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/press.html
+++ b/press.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Press</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Press</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>Press</h1><p class='lede'>Media resources and contact information.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Privacy</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Privacy</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>Privacy Policy</h1><p class='lede'>Your privacy is important to us. Read our policy.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/products.html
+++ b/products.html
@@ -26,13 +26,128 @@
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .prose p{ margin: 14px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
 </head>
 <body>
-  <div class="container">
-    <h1>Products</h1>
-    <p><a href="index.html">Back to Home</a></p>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <main id="content">
+    <section class="hero">
+      <div class="container">
+        <h1>Our Products</h1>
+        <p class="lede">Discover our range of products designed to enhance the learning experience for everyone.</p>
+      </div>
+    </section>
+
+    <article class="container">
+      <div class="prose">
+        <p>At Stomatomi, we offer a variety of tools and platforms tailored to the needs of modern education. Whether you are a student, a teacher, or a school administrator, our products are built to be intuitive, engaging, and effective.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </div>
+    </article>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/schools.html
+++ b/schools.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Schools</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Schools</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>For Schools</h1><p class='lede'>Learn how Stomatomi can be integrated into your school's curriculum.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Signin</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Signin</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>Sign In</h1><p class='lede'>Access your Stomatomi account.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/status.html
+++ b/status.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Status</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Status</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>System Status</h1><p class='lede'>Check the current status of our services.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/students.html
+++ b/students.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Students</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Students</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>For Students</h1><p class='lede'>Explore a new way of learning with our interactive platform.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/teachers.html
+++ b/teachers.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Teachers</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Teachers</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>For Teachers</h1><p class='lede'>Tools and resources for teachers to create engaging lesson plans.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -4,24 +4,154 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stomatomi — Terms</title>
+  <meta name="description" content="Official announcement: Atomi is rebranding to Stomatomi — a fresh identity inspired by stomata." />
   <link rel="icon" type="image/x-icon" href="logo.png" />
   <style>
     :root{
-      --blue: #1769ff;
+      --blue: #1769ff; /* brand blue */
+      --blue-600: #1557ff;
+      --ink: #0b1220; /* primary text */
+      --muted: #5a6b85; /* secondary text */
+      --line: #e7edf5; /* borders */
+      --bg: #ffffff; /* page */
+      --surface: #ffffff; /* cards */
+      --radius: 14px;
+      --shadow: 0 6px 18px rgba(16, 34, 68, 0.08);
       --maxw: 960px;
     }
+    *{ box-sizing: border-box; }
     body{
       margin:0; font: 16px/1.65 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans";
+      color: var(--ink); background: var(--bg);
     }
     a{ color: var(--blue); text-decoration: none; }
     .container{ width: min(100%, var(--maxw)); margin: 0 auto; padding: 0 20px; }
+
+    /* Top note */
+    .note{ background: #eef4ff; color:#0a2a6a; border-bottom: 1px solid #dfe9ff; }
+    .note .container{ padding: 10px 0; font-weight: 600; }
+
+    /* Header */
+    header{ position: sticky; top:0; z-index:10; background: rgba(255,255,255,.8); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+    .nav{ display:flex; align-items:center; justify-content:space-between; padding: 14px 0; }
+    .brand{ display:flex; align-items:center; gap:12px; }
+    .brand img{ height:28px; width:auto; display:block; }
+    .brand .name{ font-weight: 800; letter-spacing:.2px; color:#1a2a44; }
+
+    .links{ display:flex; gap:10px; align-items:center; }
+    .links a{ color:#2a3b52; padding:8px 10px; border-radius:10px; }
+    .links a[aria-disabled="true"]{ color:#6b7c93; cursor: not-allowed; }
+    .links a:hover{ background:#f4f7fb; }
+    .cta{ border:1px solid var(--line); padding:8px 12px; border-radius:10px; color:#1c2a45; }
+    .btn{ background: var(--blue); color:#fff; padding:8px 12px; border-radius:10px; font-weight:700; box-shadow: var(--shadow); }
+
+    .hamburger{ display:none; border:0; background:none; font-size:20px; }
+    @media (max-width: 820px){
+      .links{ display:none; position:absolute; left:0; right:0; top:62px; background:#fff; border-bottom:1px solid var(--line); padding:10px 20px; }
+      .links.open{ display:flex; flex-direction:column; align-items:flex-start; }
+      .hamburger{ display:block; }
+    }
+
+    /* Hero */
+    .hero{ padding: 36px 0 12px; border-bottom:1px solid var(--line); }
+    .eyebrow{ display:inline-block; font-size:12px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:#2850b8; background:#eef4ff; padding:6px 10px; border-radius:999px; }
     h1{ font-size: clamp(28px, 5vw, 44px); line-height:1.1; margin: 12px 0 6px; }
+    .lede{ color: var(--muted); max-width: 70ch; }
+
+    /* Article */
+    article{ margin: 28px 0 40px; }
+    .meta{ color:#6a7a92; font-size:14px; margin-bottom: 8px; }
+    .prose p{ margin: 14px 0; }
+    .callout{ background:#f7fbff; border:1px solid #dfe9ff; padding:12px 14px; border-radius:12px; }
+
+    .grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0; }
+    .card{ background: var(--surface); border:1px solid var(--line); border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+    .card h3{ margin:4px 0 6px; font-size:18px; }
+    .muted{ color: var(--muted); }
+
+    /* Image Compare Section */
+    .compare{ margin:40px 0; display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+    .compare img{ width:100%; border-radius: var(--radius); border:1px solid var(--line); box-shadow: var(--shadow); }
+    .compare h3{ text-align:center; margin-top:8px; color:var(--muted); font-size:14px; }
+    @media (max-width: 820px){ .compare{ grid-template-columns:1fr; } }
+
+    /* FAQ */
+    details{ background:#fff; border:1px solid var(--line); border-radius:12px; padding: 10px 12px; }
+    details + details{ margin-top: 8px; }
+    summary{ cursor:pointer; font-weight:700; }
+
+    /* Timeline */
+    .timeline{ padding-left: 18px; border-left:2px solid #dfe9ff; }
+    .timeline li{ margin: 10px 0; }
+
+    /* Footer */
+    footer{ border-top:1px solid var(--line); padding:24px 0 40px; background: #fafcff; color:#4a5a72; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; }
+    .footer-grid a{ color:#556781; }
+    .tiny{ font-size:12px; color:#6c7f99; }
+    @media (max-width: 820px){ .footer-grid{ grid-template-columns: 1fr 1fr; } }
   </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Terms</h1>
-    <p><a href="index.html">Back to Home</a></p>
+</head><body>
+
+  <div class="note">
+    <div class="container">Brand update: Atomi is becoming <strong>Stomatomi</strong>.</div>
   </div>
+
+  <header>
+    <div class="container nav">
+      <div class="brand">
+        <img src="logo.png" alt="Stomatomi logo" />
+        <span class="name">Stomatomi</span>
+      </div>
+      <nav class="menu">
+        <button class="hamburger" aria-expanded="false" aria-controls="nav-links" onclick="toggleMenu(this)">☰</button>
+        <div id="nav-links" class="links">
+          <a href="products.html">Products</a>
+          <a href="schools.html">Schools</a>
+          <a href="teachers.html">Teachers</a>
+          <a href="students.html">Students</a>
+          <a href="blog.html">Blog</a>
+          <a href="signin.html" class="cta">Sign in</a>
+          <a class="btn" href="get-started.html" style="color: white !important">Get started</a>
+        </div>
+      </nav>
+    </div>
+  </header><main id='content'><section class='hero'><div class='container'><h1>Terms of Service</h1><p class='lede'>Read our terms of service.</p></div></section></main>
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <div class="brand" style="margin-bottom:8px">
+          <img src="logo.png" alt="Stomatomi logo small" />
+          <span class="name">Stomatomi</span>
+        </div>
+        <p class="tiny">© 2025 Stomatomi. All rights reserved.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="about.html">About</a><br>
+        <a href="careers.html">Careers</a><br>
+        <a href="press.html">Press</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="help-center.html">Help Center</a><br>
+        <a href="guides.html">Guides</a><br>
+        <a href="status.html">Status</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a><br>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    function toggleMenu(btn){
+      const links = document.getElementById('nav-links');
+      const open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
This commit adds placeholder content to all the newly created secondary pages (e.g., Products, About, Careers).

The following changes have been made:
- Each of the 15 placeholder pages has been updated to include a hero section with a title and a short description.
- The HTML structure of these pages now mirrors `index.html`, including the header, footer, and all CSS styles, to ensure a consistent user experience across the site.